### PR TITLE
upload secrets to marblerun

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ era-config.json
 tensorflow.crt
 model_key
 manifest.json
+enclave-key.pem
+user_credentials*

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ You can run the demo with Marblerun in standalone mode as follows:
 
 1. Generate a user certificate and key.
     ```bash
-    openssl req -x509 -newkey rsa:4096 -sha256 -days 3650 -nodes -keyout user_credentials.key -out user_credentials.crt
+    openssl req -x509 -newkey rsa:4096 -sha256 -nodes -keyout user_credentials.key -out user_credentials.crt
     ```
 
 1. Insert the output of the following command as `Certificate` for user `tf-admin` in `tf-server-manifest.json`
@@ -138,7 +138,7 @@ If you built your own image you will have to change the image name in `kubernete
 
 1. Generate a user certificate and key.
     ```bash
-    openssl req -x509 -newkey rsa:4096 -sha256 -days 3650 -nodes -keyout user_credentials.key -out user_credentials.crt
+    openssl req -x509 -newkey rsa:4096 -sha256 -nodes -keyout user_credentials.key -out user_credentials.crt
     ```
 
 1. Insert the output of the following command as `Certificate` for user `tf-admin` in `tf-server-manifest.json`

--- a/pf_key.json
+++ b/pf_key.json
@@ -1,0 +1,5 @@
+{
+    "pf_key": {
+        "Key": "KEY_DATA"
+    }
+}

--- a/tf-server-manifest.json
+++ b/tf-server-manifest.json
@@ -29,13 +29,39 @@
                 ],
                 "Files": {
                     "ssl.cfg": "server_key: '-----BEGIN PRIVATE KEY-----\\n{{ base64 .Marblerun.MarbleCert.Private }}\\n-----END PRIVATE KEY-----'\nserver_cert: '-----BEGIN CERTIFICATE-----\\n{{ base64 .Marblerun.MarbleCert.Cert }}\\n-----END CERTIFICATE-----'\nclient_verify: false",
-                    "/dev/attestation/protected_files_key": "YOUR_KEY_HERE"
-                },
-                "Env": {
-                    "ISGX_DRIVER_PATH": "/graphene/Pal/src/host/Linux-SGX/linux-sgx-driver",
-                    "WORK_BASE_PATH": "/graphene/Examples/tensorflow-marblerun"
+                    "/dev/attestation/protected_files_key": "{{ hex .Secrets.pf_key }}"
                 }
             }
+        }
+    },
+    "Secrets": {
+        "pf_key": {
+            "Type": "symmetric-key",
+            "Size": 128,
+            "UserDefined": true
+        }
+    },
+    "Users": {
+        "tf-admin": {
+            "Certificate": "USER_CERT",
+            "Roles": [
+                "secret-manager"
+            ],
+            "WriteSecret": [
+                "pf_key"
+            ]
+        }
+    },
+    "Roles": {
+        "secret-manager": {
+            "ResourceType": "Secrets",
+            "ResourceNames": [
+                "pf_key"
+            ],
+            "Actions": [
+                "WriteSecret",
+                "ReadSecret"
+            ]
         }
     }
 }

--- a/tools/run_tf_image.sh
+++ b/tools/run_tf_image.sh
@@ -6,10 +6,11 @@ attestation_hosts="localhost:127.0.0.1"
 work_base_path=/graphene/Examples/tensorflow-marblerun
 mount_dir=`pwd -P`
 host_ports="8500-8501"
-image_id=${$1:-ghcr.io/edgelesssys/tensorflow-graphene-marble:latest}
+image_id=ghcr.io/edgelesssys/tensorflow-graphene-marble:latest
 
 docker run \
     -it \
+    --rm \
     --privileged \
     --device /dev/sgx \
     --network host \
@@ -17,8 +18,6 @@ docker run \
     -p ${host_ports}:8500-8501 \
     -v ${mount_dir}/models:${work_base_path}/models \
     -v /var/run/aesmd:/var/run/aesmd \
-    -e SGX=1 \
-    -e ISGX_DRIVER_PATH=/graphene/Pal/src/host/Linux-SGX/linux-sgx-driver \
     -e EDG_MARBLE_TYPE=tf-server \
     -e EDG_UUID_FILE="/tf_server-uid/uuid-file" \
     -e EDG_MARBLE_COORDINATOR_ADDR=grpc.tf-serving.service.com:2001 \


### PR DESCRIPTION
Updates readme and manifest to make use of Marbleruns `/secrets` endpoint. 
The protected files key is no longer set in the manifest, but uploaded at a later date by a user, keeping it confidential while in use.

Currently following this example requires building Marblerun yourself, since these changes have not yet been packaged into a new Marblerun release.